### PR TITLE
leave tag_prefix blank for versioneer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ VCS = git
 style = pep440
 versionfile_source = Python/ogusa/_version.py
 versionfile_build = ogusa/_version.py
-tag_prefix = ''
+tag_prefix = 


### PR DESCRIPTION
Trivial change to setup.cfg so that versioneer will properly recognize versions based on git tags.