### PR TITLE
update label for Frisch elasticity parameter

### DIFF
--- a/Python/ogusa/parameters_metadata.json
+++ b/Python/ogusa/parameters_metadata.json
@@ -7,11 +7,11 @@
         "col_label": ["Growth rate of technology"]
     },
     "frisch":{
-        "long_name": "omega for elliptical fit utility function",
+        "long_name": "Frisch elastictiy of labor supply used to fit elliptical utility",
 	    "description": "The Frisch elasticity gives the elasticity of labor supply to changes in the net of tax wage rate, holding wealth constant.   This means that the Frisch elasticity captures the substitution effects, but not the income effects, of a change in the net of tax wage rate.  A Frisch elasticity of 0.4 would indicate that if the net of tax wage rate increases by 10% then hours worked would increase by 4%, if wealth were held constant.  Note that OG-USA uses an elliptical utility function for labor supply.  We parameterize this function to fit a constant Frisch elasticity function with a Frisch elasticity as input here.",
         "irs_ref": "",
         "notes": "",
-        "col_label": ["Frisch"],
+        "col_label": ["Frisch elasticity"],
         "validations": {"min": 0.1, "max": 0.8 }
     }
 }


### PR DESCRIPTION
This PR simply changes the label for the box where the Frisch elasticity parameters used in OG-USA is entered. The new name is more descriptive.