### PR TITLE
add non-age-specific tax functions

### DIFF
--- a/Python/execute.py
+++ b/Python/execute.py
@@ -64,7 +64,7 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, reform=
 
     
     get_baseline = True
-    calibrate_model = False
+    calibrate_model = True
     # List of parameter names that will not be changing (unless we decide to
     # change them for a tax experiment)
 

--- a/Python/execute_large.py
+++ b/Python/execute_large.py
@@ -12,7 +12,7 @@ import ogusa
 ogusa.parameters.DATASET = 'REAL'
 
 
-def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, reform={}, user_params={}, guid='', run_micro=True):
+def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, age_specific=False, reform={}, user_params={}, guid='', run_micro=True):
 
     from ogusa import parameters, wealth, labor, demographics, income
     from ogusa import txfunc
@@ -32,7 +32,7 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, reform=
             pass
 
     if run_micro:
-        txfunc.get_tax_func_estimate(baseline=baseline, analytical_mtrs=analytical_mtrs, reform=reform, guid=guid)
+        txfunc.get_tax_func_estimate(baseline=baseline, analytical_mtrs=analytical_mtrs, age_specific=age_specific, reform=reform, guid=guid)
     print ("in runner, baseline is ", baseline)
     run_params = ogusa.parameters.get_parameters(baseline=baseline, guid=guid)
     run_params['analytical_mtrs'] = analytical_mtrs

--- a/Python/ogusa/SS.py
+++ b/Python/ogusa/SS.py
@@ -558,7 +558,7 @@ def run_steady_state(income_tax_parameters, ss_parameters, iterative_params, get
     chi_params[J:] = chi_n_guess
     # First run SS simulation with guesses at initial values for b, n, w, r, etc
     # For inital guesses of b and n, we choose very small b, and medium n
-    b_guess = np.ones((S, J)).flatten() * .05
+    b_guess = np.ones((S, J)).flatten() * 0.05
     n_guess = np.ones((S, J)).flatten() * .4 * ltilde
     # For initial guesses of w, r, T_H, and factor, we use values that are close
     # to some steady state values.

--- a/Python/run_ogusa_serial.py
+++ b/Python/run_ogusa_serial.py
@@ -1,0 +1,77 @@
+import ogusa
+import os
+import sys
+from multiprocessing import Process
+import time
+
+#OGUSA_PATH = os.environ.get("OGUSA_PATH", "../../ospc-dynamic/dynamic/Python")
+
+#sys.path.append(OGUSA_PATH)
+
+import postprocess
+#from execute import runner # change here for small jobs
+from execute_large import runner
+
+
+def run_micro_macro(user_params):
+
+    # reform = {
+    # 2015: {
+    #     '_II_rt1': [.09],
+    #     '_II_rt2': [.135],
+    #     '_II_rt3': [.225],
+    #     '_II_rt4': [.252],
+    #     '_II_rt5': [.297],
+    #     '_II_rt6': [.315],
+    #     '_II_rt7': [0.3564],
+    # }, }
+
+    reform = {
+    2015: {
+        '_II_rt7': [0.35],
+    }, }
+
+
+    start_time = time.time()
+
+    REFORM_DIR = "./OUTPUT_REFORM"
+    BASELINE_DIR = "./OUTPUT_BASELINE"
+
+    output_base = REFORM_DIR
+    input_dir = REFORM_DIR
+
+    guid_iter = 'reform_' + str(0)
+
+    
+    kwargs={'output_base':output_base, 'input_dir':input_dir,
+            'baseline':False, 'analytical_mtrs':True, 'age_specific':False, 
+            'reform':reform, 'user_params':user_params,'guid':'99', 'run_micro':True}
+    #p2 = Process(target=runner, kwargs=kwargs)
+    #p2.start()
+    runner(**kwargs)
+
+    output_base = BASELINE_DIR
+    input_dir = BASELINE_DIR
+    kwargs={'output_base':output_base, 'input_dir':input_dir,
+            'baseline':True, 'analytical_mtrs':True, 'age_specific':False,
+            'user_params':user_params,'guid':'99',
+            'run_micro':True}
+    #p1 = Process(target=runner, kwargs=kwargs)
+    #p1.start()
+    runner(**kwargs)
+
+    #p1.join()
+    print "just joined"
+    #p2.join()
+
+    time.sleep(0.5)
+
+    ans = postprocess.create_diff(baseline=BASELINE_DIR, policy=REFORM_DIR)
+
+    print "total time was ", (time.time() - start_time)
+    print ans
+
+    return ans
+
+if __name__ == "__main__":
+    run_micro_macro(user_params={})


### PR DESCRIPTION
This PR allows the user to estimate tax functions by tax year, but not by age.  Previously, tax functions were estimated separately by age and year.  