### PR TITLE
Baseline SS results used for reform

### DIFF
--- a/Python/execute.py
+++ b/Python/execute.py
@@ -12,7 +12,7 @@ import ogusa
 ogusa.parameters.DATASET = 'SMALL'
 
 
-def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, reform={}, user_params={}, guid='', run_micro=True):
+def runner(output_base, baseline_dir, baseline=False, analytical_mtrs=True, age_specific=False, reform={}, user_params={}, guid='', run_micro=True):
 
     from ogusa import parameters, wealth, labor, demographics, income
     from ogusa import txfunc
@@ -81,11 +81,10 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, reform=
 
     '''
     ------------------------------------------------------------------------
-        Run SS with minimization to fit chi_b and chi_n
+        Run SS
     ------------------------------------------------------------------------
     '''
 
-    # This is the simulation before getting the replacement rate values
     sim_params = {}
     glbs = globals()
     lcls = locals()
@@ -104,7 +103,7 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, reform=
 
     '''
     ------------------------------------------------------------------------
-        Run the baseline TPI simulation
+        Run TPI
     ------------------------------------------------------------------------
     '''
 
@@ -144,3 +143,93 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, reform=
     print "getting to here...."
     TPI.TP_solutions(w_path, r_path, T_H_path, BQ_path, **ss_outputs)
     print "took {0} seconds to get that part done.".format(time.time() - tick)
+
+
+def runner_SS(output_base, baseline_dir, baseline=False, analytical_mtrs=True, age_specific=False, reform={}, user_params={}, guid='', run_micro=True):
+
+    from ogusa import parameters, wealth, labor, demographics, income
+    from ogusa import txfunc
+
+    tick = time.time()
+
+    #Create output directory structure
+    saved_moments_dir = os.path.join(output_base, "Saved_moments")
+    ssinit_dir = os.path.join(output_base, "SSinit")
+    tpiinit_dir = os.path.join(output_base, "TPIinit")
+    dirs = [saved_moments_dir, ssinit_dir, tpiinit_dir]
+    for _dir in dirs:
+        try:
+            print "making dir: ", _dir
+            os.makedirs(_dir)
+        except OSError as oe:
+            pass
+
+    if run_micro:
+        txfunc.get_tax_func_estimate(baseline=baseline, analytical_mtrs=analytical_mtrs, reform=reform, guid=guid)
+    print ("in runner, baseline is ", baseline)
+    run_params = ogusa.parameters.get_parameters(baseline=baseline, guid=guid)
+    run_params['analytical_mtrs'] = analytical_mtrs
+
+    # Modify ogusa parameters based on user input
+    if 'frisch' in user_params:
+        print "updating fricsh and associated"
+        b_ellipse, upsilon = ogusa.elliptical_u_est.estimation(user_params['frisch'],
+                                                               run_params['ltilde'])
+        run_params['b_ellipse'] = b_ellipse
+        run_params['upsilon'] = upsilon
+        run_params.update(user_params)
+
+    # Modify ogusa parameters based on user input
+    if 'g_y_annual' in user_params:
+        print "updating g_y_annual and associated"
+        g_y = (1 + user_params['g_y_annual'])**(float(ending_age - starting_age) / S) - 1
+        run_params['g_y'] = g_y
+        run_params.update(user_params)
+
+    globals().update(run_params)
+
+    from ogusa import SS, TPI
+    # Generate Wealth data moments
+    wealth.get_wealth_data(lambdas, J, flag_graphs, output_dir=input_dir)
+
+    # Generate labor data moments
+    labor.labor_data_moments(flag_graphs, output_dir=input_dir)
+
+    
+    get_baseline = True
+    calibrate_model = True
+    # List of parameter names that will not be changing (unless we decide to
+    # change them for a tax experiment)
+
+    param_names = ['S', 'J', 'T', 'BW', 'lambdas', 'starting_age', 'ending_age',
+                'beta', 'sigma', 'alpha', 'nu', 'Z', 'delta', 'E',
+                'ltilde', 'g_y', 'maxiter', 'mindist_SS', 'mindist_TPI',
+                'analytical_mtrs', 'b_ellipse', 'k_ellipse', 'upsilon',
+                'chi_b_guess', 'chi_n_guess','etr_params','mtrx_params',
+                'mtry_params','tau_payroll', 'tau_bq', 'calibrate_model',
+                'retire', 'mean_income_data', 'g_n_vector',
+                'h_wealth', 'p_wealth', 'm_wealth', 'get_baseline',
+                'omega', 'g_n_ss', 'omega_SS', 'surv_rate', 'e', 'rho']
+
+
+    '''
+    ------------------------------------------------------------------------
+        Run SS
+    ------------------------------------------------------------------------
+    '''
+
+    sim_params = {}
+    glbs = globals()
+    lcls = locals()
+    for key in param_names:
+        if key in glbs:
+            sim_params[key] = glbs[key]
+        else:
+            sim_params[key] = lcls[key]
+
+    sim_params['output_dir'] = input_dir
+    sim_params['run_params'] = run_params
+
+    income_tax_params, wealth_tax_params, ellipse_params, ss_parameters, iterative_params = SS.create_steady_state_parameters(**sim_params)
+
+    ss_outputs = SS.run_steady_state(income_tax_params, ss_parameters, iterative_params, get_baseline, calibrate_model, output_dir=input_dir)

--- a/Python/execute_large.py
+++ b/Python/execute_large.py
@@ -14,7 +14,8 @@ ogusa.parameters.DATASET = 'REAL'
 
 def runner(output_base, baseline_dir, baseline=False, analytical_mtrs=True, age_specific=False, reform={}, user_params={}, guid='', run_micro=True):
 
-    from ogusa import parameters, wealth, labor, demographics, income
+    #from ogusa import parameters, wealth, labor, demographics, income
+    from ogusa import parameters, wealth, labor, demog, income
     from ogusa import txfunc
 
     tick = time.time()

--- a/Python/execute_large.py
+++ b/Python/execute_large.py
@@ -12,7 +12,7 @@ import ogusa
 ogusa.parameters.DATASET = 'REAL'
 
 
-def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, age_specific=False, reform={}, user_params={}, guid='', run_micro=True):
+def runner(output_base, baseline_dir, baseline=False, analytical_mtrs=True, age_specific=False, reform={}, user_params={}, guid='', run_micro=True):
 
     from ogusa import parameters, wealth, labor, demographics, income
     from ogusa import txfunc
@@ -57,13 +57,12 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, age_spe
 
     from ogusa import SS, TPI
     # Generate Wealth data moments
-    wealth.get_wealth_data(lambdas, J, flag_graphs, output_dir=input_dir)
+    wealth.get_wealth_data(lambdas, J, flag_graphs, output_dir=output_base)
 
     # Generate labor data moments
-    labor.labor_data_moments(flag_graphs, output_dir=input_dir)
+    labor.labor_data_moments(flag_graphs, output_dir=output_base)
 
     
-    get_baseline = True
     calibrate_model = False
     # List of parameter names that will not be changing (unless we decide to
     # change them for a tax experiment)
@@ -75,17 +74,16 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, age_spe
                 'chi_b_guess', 'chi_n_guess','etr_params','mtrx_params',
                 'mtry_params','tau_payroll', 'tau_bq', 'calibrate_model',
                 'retire', 'mean_income_data', 'g_n_vector',
-                'h_wealth', 'p_wealth', 'm_wealth', 'get_baseline',
+                'h_wealth', 'p_wealth', 'm_wealth',
                 'omega', 'g_n_ss', 'omega_SS', 'surv_rate', 'e', 'rho']
 
 
     '''
     ------------------------------------------------------------------------
-        Run SS with minimization to fit chi_b and chi_n
+        Run SS 
     ------------------------------------------------------------------------
     '''
 
-    # This is the simulation before getting the replacement rate values
     sim_params = {}
     glbs = globals()
     lcls = locals()
@@ -95,12 +93,13 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, age_spe
         else:
             sim_params[key] = lcls[key]
 
-    sim_params['output_dir'] = input_dir
+    sim_params['output_dir'] = output_base
     sim_params['run_params'] = run_params
 
     income_tax_params, wealth_tax_params, ellipse_params, ss_parameters, iterative_params = SS.create_steady_state_parameters(**sim_params)
 
-    ss_outputs = SS.run_steady_state(income_tax_params, ss_parameters, iterative_params, get_baseline, calibrate_model, output_dir=input_dir)
+    ss_outputs = SS.run_steady_state(income_tax_params, ss_parameters, iterative_params, baseline, 
+                                     calibrate_model, output_dir=output_base, baseline_dir=baseline_dir)
 
 
     '''
@@ -109,10 +108,10 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, age_spe
     ------------------------------------------------------------------------
     '''
 
-    ss_outputs['get_baseline'] = get_baseline
-    sim_params['input_dir'] = input_dir
+    sim_params['input_dir'] = output_base
+    sim_params['baseline_dir'] = baseline_dir
     income_tax_params, wealth_tax_params, ellipse_params, parameters, N_tilde, omega_stationary, K0, b_sinit, \
-    b_splus1init, L0, Y0, w0, r0, BQ0, T_H_0, tax0, c0, initial_b, initial_n = TPI.create_tpi_params(**sim_params)
+    b_splus1init, L0, Y0, w0, r0, BQ0, T_H_0, factor, tax0, c0, initial_b, initial_n = TPI.create_tpi_params(**sim_params)
     ss_outputs['income_tax_params'] = income_tax_params
     ss_outputs['wealth_tax_params'] = wealth_tax_params
     ss_outputs['ellipse_params'] = ellipse_params
@@ -127,13 +126,14 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, age_spe
     ss_outputs['r0'] = r0
     ss_outputs['BQ0'] = BQ0
     ss_outputs['T_H_0'] = T_H_0
+    ss_outputs['factor_ss'] = factor
     ss_outputs['tax0'] = tax0
     ss_outputs['c0'] = c0
     ss_outputs['initial_b'] = initial_b
     ss_outputs['initial_n'] = initial_n
     ss_outputs['tau_bq'] = tau_bq
     ss_outputs['g_n_vector'] = g_n_vector
-    ss_outputs['output_dir'] = input_dir
+    ss_outputs['output_dir'] = output_base
 
 
     with open("ss_outputs.pkl", 'wb') as fp:
@@ -145,3 +145,94 @@ def runner(output_base, input_dir, baseline=False, analytical_mtrs=True, age_spe
     print "getting to here...."
     TPI.TP_solutions(w_path, r_path, T_H_path, BQ_path, **ss_outputs)
     print "took {0} seconds to get that part done.".format(time.time() - tick)
+
+
+def runner_SS(output_base, baseline_dir, baseline=False, analytical_mtrs=True, age_specific=False, reform={}, user_params={}, guid='', run_micro=True):
+
+    from ogusa import parameters, wealth, labor, demographics, income
+    from ogusa import txfunc
+
+    tick = time.time()
+
+    #Create output directory structure
+    saved_moments_dir = os.path.join(output_base, "Saved_moments")
+    ssinit_dir = os.path.join(output_base, "SSinit")
+    tpiinit_dir = os.path.join(output_base, "TPIinit")
+    dirs = [saved_moments_dir, ssinit_dir, tpiinit_dir]
+    for _dir in dirs:
+        try:
+            print "making dir: ", _dir
+            os.makedirs(_dir)
+        except OSError as oe:
+            pass
+
+    if run_micro:
+        txfunc.get_tax_func_estimate(baseline=baseline, analytical_mtrs=analytical_mtrs, age_specific=age_specific, reform=reform, guid=guid)
+    print ("in runner, baseline is ", baseline)
+    run_params = ogusa.parameters.get_parameters(baseline=baseline, guid=guid)
+    run_params['analytical_mtrs'] = analytical_mtrs
+
+    # Modify ogusa parameters based on user input
+    if 'frisch' in user_params:
+        print "updating fricsh and associated"
+        b_ellipse, upsilon = ogusa.elliptical_u_est.estimation(user_params['frisch'],
+                                                               run_params['ltilde'])
+        run_params['b_ellipse'] = b_ellipse
+        run_params['upsilon'] = upsilon
+        run_params.update(user_params)
+
+    # Modify ogusa parameters based on user input
+    if 'g_y_annual' in user_params:
+        print "updating g_y_annual and associated"
+        g_y = (1 + user_params['g_y_annual'])**(float(ending_age - starting_age) / S) - 1
+        run_params['g_y'] = g_y
+        run_params.update(user_params)
+
+    globals().update(run_params)
+
+    from ogusa import SS, TPI
+    # Generate Wealth data moments
+    wealth.get_wealth_data(lambdas, J, flag_graphs, output_dir=output_base)
+
+    # Generate labor data moments
+    labor.labor_data_moments(flag_graphs, output_dir=output_base)
+
+    
+    calibrate_model = False
+    # List of parameter names that will not be changing (unless we decide to
+    # change them for a tax experiment)
+
+    param_names = ['S', 'J', 'T', 'BW', 'lambdas', 'starting_age', 'ending_age',
+                'beta', 'sigma', 'alpha', 'nu', 'Z', 'delta', 'E',
+                'ltilde', 'g_y', 'maxiter', 'mindist_SS', 'mindist_TPI',
+                'analytical_mtrs', 'b_ellipse', 'k_ellipse', 'upsilon',
+                'chi_b_guess', 'chi_n_guess','etr_params','mtrx_params',
+                'mtry_params','tau_payroll', 'tau_bq', 'calibrate_model',
+                'retire', 'mean_income_data', 'g_n_vector',
+                'h_wealth', 'p_wealth', 'm_wealth',
+                'omega', 'g_n_ss', 'omega_SS', 'surv_rate', 'e', 'rho']
+
+
+    '''
+    ------------------------------------------------------------------------
+        Run SS 
+    ------------------------------------------------------------------------
+    '''
+
+    sim_params = {}
+    glbs = globals()
+    lcls = locals()
+    for key in param_names:
+        if key in glbs:
+            sim_params[key] = glbs[key]
+        else:
+            sim_params[key] = lcls[key]
+
+    sim_params['output_dir'] = output_base
+    sim_params['run_params'] = run_params
+
+    income_tax_params, wealth_tax_params, ellipse_params, ss_parameters, iterative_params = SS.create_steady_state_parameters(**sim_params)
+
+    ss_outputs = SS.run_steady_state(income_tax_params, ss_parameters, iterative_params, baseline, 
+                                     calibrate_model, output_dir=output_base, baseline_dir=baseline_dir)
+

--- a/Python/ogusa/SS.py
+++ b/Python/ogusa/SS.py
@@ -394,7 +394,7 @@ def SS_fsolve(guesses, b_guess_init, n_guess_init, chi_n, chi_b, tax_params, par
     error1 = new_w - w
     error2 = new_r - r
     error3 = new_T_H - T_H
-    error4 = new_factor - factor
+    error4 = new_factor/1000000 - factor/1000000
     print 'errors: ', error1, error2, error3, error4
     print 'T_H: ', new_T_H
     print 'factor: ', new_factor
@@ -814,6 +814,7 @@ def run_steady_state(income_tax_parameters, ss_parameters, iterative_params, bas
     resource_constraint = Yss - (Css + Iss)
 
     print 'Resource Constraint Difference:', resource_constraint
+    print 'SS pop growth: ', g_n_ss
 
     constraint_params = ltilde
     household.constraint_checker_SS(bssmat, nssmat, cssmat, constraint_params)

--- a/Python/ogusa/TPI.py
+++ b/Python/ogusa/TPI.py
@@ -53,8 +53,8 @@ steady state computation in ss_vars.pkl
 def create_tpi_params(analytical_mtrs, etr_params, mtrx_params, mtry_params,
                       b_ellipse, upsilon, J, S, T, BW, beta, sigma, alpha, Z,
                       delta, ltilde, nu, g_y, tau_payroll, retire,
-                      mean_income_data, run_params, get_baseline=True,
-                      input_dir="./OUTPUT", **kwargs):
+                      mean_income_data, run_params,
+                      input_dir="./OUTPUT", baseline_dir="./OUTPUT", **kwargs):
 
     globals().update(run_params)
 
@@ -62,6 +62,17 @@ def create_tpi_params(analytical_mtrs, etr_params, mtrx_params, mtry_params,
     variables = pickle.load(open(ss_init, "rb"))
     for key in variables:
         globals()[key] = variables[key]
+
+    '''
+    ------------------------------------------------------------------------
+    Set factor and initial capital stock to SS from baseline
+    ------------------------------------------------------------------------
+    '''
+    baseline_ss = os.path.join(baseline_dir, "SSinit/ss_init_vars.pkl")
+    ss_baseline_vars = pickle.load(open(baseline_ss, "rb"))
+    factor = ss_baseline_vars['factor_ss']
+    #initial_b = ss_baseline_vars['bssmat_s'] + ss_baseline_vars['BQss']/lambdas
+    initial_b= ss_baseline_vars['bssmat_splus1'] 
 
 
     '''
@@ -98,13 +109,14 @@ def create_tpi_params(analytical_mtrs, etr_params, mtrx_params, mtry_params,
     N_tilde = omega.sum(1)
     omega_stationary = omega / N_tilde.reshape(T + S, 1)
 
-    initial_b = bssmat_splus1
     initial_n = nssmat
 
     # Get an initial distribution of capital with the initial population
     # distribution
     K0 = household.get_K(initial_b, omega_stationary[
                          0].reshape(S, 1), lambdas, g_n_vector[0], 'SS')
+
+
     b_sinit = np.array(list(np.zeros(J).reshape(1, J)) + list(initial_b[:-1]))
     b_splus1init = initial_b
     L0 = firm.get_L(e, initial_n, omega_stationary[
@@ -127,7 +139,7 @@ def create_tpi_params(analytical_mtrs, etr_params, mtrx_params, mtry_params,
 
     return (income_tax_params, wealth_tax_params, ellipse_params, parameters,
             N_tilde, omega_stationary, K0, b_sinit, b_splus1init, L0, Y0,
-            w0, r0, BQ0, T_H_0, tax0, c0, initial_b, initial_n)
+            w0, r0, BQ0, T_H_0, factor, tax0, c0, initial_b, initial_n)
 
 
 def SS_TPI_firstdoughnutring(guesses, winit, rinit, BQinit, T_H_init, initial_b, factor_ss, j, tax_params, parameters, theta, tau_bq):
@@ -285,7 +297,7 @@ def Steady_state_TPI_solver(guesses, winit, rinit, BQinit, T_H_init, factor, j, 
 def TPI_fsolve(guesses, Kss, Lss, Yss, BQss, theta, income_tax_params, wealth_tax_params, ellipse_params, parameters, g_n_vector, 
                            omega_stationary, K0, b_sinit, b_splus1init, L0, Y0, r0, BQ0, 
                            T_H_0, tax0, c0, initial_b, initial_n, factor_ss, tau_bq, chi_b, 
-                           chi_n, get_baseline=False, output_dir="./OUTPUT", **kwargs):
+                           chi_n, output_dir="./OUTPUT", **kwargs):
 
     J, S, T, BW, beta, sigma, alpha, Z, delta, ltilde, nu, g_y, g_n_ss, tau_payroll, retire, mean_income_data, \
         h_wealth, p_wealth, m_wealth, b_ellipse, upsilon = parameters
@@ -476,13 +488,12 @@ def TPI_fsolve(guesses, Kss, Lss, Yss, BQss, theta, income_tax_params, wealth_ta
 def run_time_path_iteration(Kss, Lss, Yss, BQss, theta, income_tax_params, wealth_tax_params, ellipse_params, parameters, g_n_vector, 
                            omega_stationary, K0, b_sinit, b_splus1init, L0, Y0, r0, BQ0, 
                            T_H_0, tax0, c0, initial_b, initial_n, factor_ss, tau_bq, chi_b, 
-                           chi_n, get_baseline=False, output_dir="./OUTPUT", **kwargs):
+                           chi_n, output_dir="./OUTPUT", **kwargs):
 
     J, S, T, BW, beta, sigma, alpha, Z, delta, ltilde, nu, g_y, g_n_ss, tau_payroll, retire, mean_income_data, \
         h_wealth, p_wealth, m_wealth, b_ellipse, upsilon = parameters
 
     analytical_mtrs, etr_params, mtrx_params, mtry_params = income_tax_params
-
 
     TPI_FIG_DIR = output_dir
     # Initialize Time paths
@@ -667,7 +678,7 @@ def run_time_path_iteration(Kss, Lss, Yss, BQss, theta, income_tax_params, wealt
 def TP_solutions(winit, rinit, T_H_init, BQinit2, Kss, Lss, Yss, BQss, theta, income_tax_params, wealth_tax_params, ellipse_params, parameters, g_n_vector, 
                            omega_stationary, K0, b_sinit, b_splus1init, L0, Y0, r0, BQ0, 
                            T_H_0, tax0, c0, initial_b, initial_n, factor_ss, tau_bq, chi_b, 
-                           chi_n, get_baseline=False, output_dir="./OUTPUT", **kwargs):
+                           chi_n, output_dir="./OUTPUT", **kwargs):
 
 
     '''

--- a/Python/ogusa/household.py
+++ b/Python/ogusa/household.py
@@ -11,7 +11,6 @@ This file calls the following files:
 
 # Packages
 import numpy as np
-
 import tax
 
 '''

--- a/Python/ogusa/parameters.py
+++ b/Python/ogusa/parameters.py
@@ -19,6 +19,7 @@ import os
 import json
 import numpy as np
 from demographics import get_omega
+from demog import get_pop_objs
 from income import get_e
 import pickle
 import txfunc
@@ -249,8 +250,10 @@ def get_reduced_parameters(baseline, guid, user_modifiable, metadata):
     chi_n_guess = np.array([5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
 
     # Generate Income and Demographic parameters
-    omega, g_n_ss, omega_SS, surv_rate, rho, g_n_vector = get_omega(
-        S, T, starting_age, ending_age, E, flag_graphs)
+    #omega, g_n_ss, omega_SS, surv_rate, rho, g_n_vector = get_omega(
+    #    S, T, starting_age, ending_age, E, flag_graphs)
+    omega, g_n_ss, omega_SS, surv_rate, rho, g_n_vector = get_pop_objs(
+        E, S, T, 0, 100, 2015, flag_graphs)
     e = np.array([[0.25, 1.25]] * 10)
     allvars = dict(locals())
 
@@ -348,7 +351,8 @@ def get_full_parameters(baseline, guid, user_modifiable, metadata):
     #   Calibration parameters
     # These guesses are close to the calibrated values
     #chi_b_guess = np.array([0.7, 0.7, 1.0, 1.2, 1.2, 1.2, 1.4])
-    chi_b_guess = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+    #chi_b_guess = np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+    chi_b_guess = np.array([5, 10, 90, 250, 250, 250, 250])
     chi_n_guess = np.array([38.12000874, 33.22762421, 25.34842241, 26.67954008, 24.41097278, 
                             23.15059004, 22.46771332, 21.85495452, 21.46242013, 22.00364263, 
                             21.57322063, 21.53371545, 21.29828515, 21.10144524, 20.8617942, 
@@ -370,6 +374,27 @@ def get_full_parameters(baseline, guid, user_modifiable, metadata):
    # Generate Income and Demographic parameters
     omega, g_n_ss, omega_SS, surv_rate, rho, g_n_vector = get_omega(
         S, T, starting_age, ending_age, E, flag_graphs)
+    # omega2, g_n_ss2, omega_SS2, surv_rate2, rho2, g_n_vector2 = get_pop_objs(
+    #     E, S, T, 0, 100, 2015, flag_graphs)
+    # print 'Differences:'
+    # print 'omega diffs: ', (np.absolute(omega-omega2)).max()
+    # print 'g_n', g_n_ss, g_n_ss2
+    # print 'omega SS diffs: ', (np.absolute(omega_SS-omega_SS2)).max()
+    # print 'surv diffs: ', (np.absolute(surv_rate- surv_rate2)).max()
+    # print 'mort diffs: ', (np.absolute(rho- rho2)).max()
+    # print 'g_n_TP diffs: ', (np.absolute(g_n_vector- g_n_vector2)).max()
+    # quit() 
+    #print 'omega_SS shape: ', omega_SS.shape
+    g_n_ss = 0.0    
+    surv_rate1 = np.ones((S,))# prob start at age S
+    surv_rate1[1:] = np.cumprod(surv_rate[:-1], dtype=float)
+    omega_SS = np.ones(S)*surv_rate1# number of each age alive at any time
+    omega_SS = omega_SS/omega_SS.sum()
+    
+    # omega = np.tile(np.reshape(omega_SS,(1,S)),(T+S,1))
+    # g_n_vector = np.tile(g_n_ss,(T+S,))
+
+
     e = get_e(S, J, starting_age, ending_age, lambdas, omega_SS, flag_graphs)
 
     allvars = dict(locals())

--- a/Python/run_ogusa_serial.py
+++ b/Python/run_ogusa_serial.py
@@ -10,7 +10,7 @@ import time
 
 import postprocess
 #from execute import runner # change here for small jobs
-from execute_large import runner
+from execute_large import runner, runner_SS
 
 
 def run_micro_macro(user_params):
@@ -37,28 +37,54 @@ def run_micro_macro(user_params):
     REFORM_DIR = "./OUTPUT_REFORM"
     BASELINE_DIR = "./OUTPUT_BASELINE"
 
+
+    '''
+    ------------------------------------------------------------------------
+        Run SS for Baseline first - so can run baseline and reform in parallel if want 
+    ------------------------------------------------------------------------
+    '''
+    output_base = BASELINE_DIR
+    input_dir = BASELINE_DIR
+    kwargs={'output_base':output_base, 'baseline_dir':BASELINE_DIR,
+            'baseline':True, 'analytical_mtrs':True, 'age_specific':False,
+            'user_params':user_params,'guid':'99',
+            'run_micro':False}
+    #p1 = Process(target=runner, kwargs=kwargs)
+    #p1.start()
+    runner_SS(**kwargs)
+    
+
+    '''
+    ------------------------------------------------------------------------
+        Run baseline
+    ------------------------------------------------------------------------
+    '''
+    output_base = BASELINE_DIR
+    input_dir = BASELINE_DIR
+    kwargs={'output_base':output_base, 'baseline_dir':BASELINE_DIR,
+            'baseline':True, 'analytical_mtrs':True, 'age_specific':False,
+            'user_params':user_params,'guid':'99',
+            'run_micro':False}
+    #p1 = Process(target=runner, kwargs=kwargs)
+    #p1.start()
+    runner(**kwargs)
+
+    '''
+    ------------------------------------------------------------------------
+        Run reform 
+    ------------------------------------------------------------------------
+    '''
     output_base = REFORM_DIR
     input_dir = REFORM_DIR
-
     guid_iter = 'reform_' + str(0)
-
-    
-    kwargs={'output_base':output_base, 'input_dir':input_dir,
+    kwargs={'output_base':output_base, 'baseline_dir':BASELINE_DIR,
             'baseline':False, 'analytical_mtrs':True, 'age_specific':False, 
-            'reform':reform, 'user_params':user_params,'guid':'99', 'run_micro':True}
+            'reform':reform, 'user_params':user_params,'guid':'99', 'run_micro':False}
     #p2 = Process(target=runner, kwargs=kwargs)
     #p2.start()
     runner(**kwargs)
 
-    output_base = BASELINE_DIR
-    input_dir = BASELINE_DIR
-    kwargs={'output_base':output_base, 'input_dir':input_dir,
-            'baseline':True, 'analytical_mtrs':True, 'age_specific':False,
-            'user_params':user_params,'guid':'99',
-            'run_micro':True}
-    #p1 = Process(target=runner, kwargs=kwargs)
-    #p1.start()
-    runner(**kwargs)
+
 
     #p1.join()
     print "just joined"

--- a/Python/run_ogusa_serial.py
+++ b/Python/run_ogusa_serial.py
@@ -53,6 +53,7 @@ def run_micro_macro(user_params):
     #p1.start()
     runner_SS(**kwargs)
     
+    quit()
 
     '''
     ------------------------------------------------------------------------


### PR DESCRIPTION
This PR makes two fixes to the model solution of the reform policies:
1) It uses the model adjustment factor (which scales model income so that it matches income from the PUF) found in the baseline SS solution to adjust model income in the reform as well.  
2) It ensures that the initial period capital stock for the reform is the same as that for the baseline.

