### PR TITLE
Fix Social Security Calibration

### DIFF
--- a/Python/ogusa/SS.py
+++ b/Python/ogusa/SS.py
@@ -208,13 +208,13 @@ def euler_equation_solver(guesses, params):
 
     BQ_params = (omega_SS, lambdas[j], rho, g_n_ss, 'SS')
     BQ = household.get_BQ(r, b_splus1, BQ_params)
-    theta_params = (e[:,j], J, omega_SS, lambdas[j])
+    theta_params = (e, S, J, omega_SS, lambdas,retire)
     theta = tax.replacement_rate_vals(n_guess, w, factor, theta_params)
 
-    foc_save_parms = (e[:, j], sigma, beta, g_y, chi_b[j], theta, tau_bq[j], rho, lambdas[j], J, S,
+    foc_save_parms = (e[:, j], sigma, beta, g_y, chi_b[j], theta[j], tau_bq[j], rho, lambdas[j], J, S,
                            analytical_mtrs, etr_params, mtry_params, h_wealth, p_wealth, m_wealth, tau_payroll, retire, 'SS')
     error1 = household.FOC_savings(r, w, b_s, b_splus1, b_splus2, n_guess, BQ, factor, T_H, foc_save_parms)
-    foc_labor_params = (e[:, j], sigma, g_y, theta, b_ellipse, upsilon, chi_n, ltilde, tau_bq[j], lambdas[j], J, S,
+    foc_labor_params = (e[:, j], sigma, g_y, theta[j], b_ellipse, upsilon, chi_n, ltilde, tau_bq[j], lambdas[j], J, S,
                             analytical_mtrs, etr_params, mtrx_params, h_wealth, p_wealth, m_wealth, tau_payroll, retire, 'SS')
     error2 = household.FOC_labor(r, w, b_s, b_splus1, n_guess, BQ, factor, T_H, foc_labor_params)
 
@@ -235,7 +235,7 @@ def euler_equation_solver(guesses, params):
     error2[mask4] = 1e14
 
     tax1_params = (e[:, j], lambdas[j], 'SS', retire, etr_params, h_wealth, p_wealth,
-                   m_wealth, tau_payroll, theta, tau_bq[j], J, S)
+                   m_wealth, tau_payroll, theta[j], tau_bq[j], J, S)
     tax1 = tax.total_taxes(r, w, b_s, n_guess, BQ, factor, T_H, None, False, tax1_params)
     cons_params = (e[:, j], lambdas[j], g_y)
     cons = household.get_cons(r, w, b_s, b_splus1, n_guess, BQ, tax1, cons_params)
@@ -359,7 +359,7 @@ def inner_loop(outer_loop_vars, params, baseline):
 
     BQ_params = (omega_SS.reshape(S, 1), lambdas.reshape(1, J), rho.reshape(S, 1), g_n_ss, 'SS')
     new_BQ = household.get_BQ(new_r, bssmat, BQ_params)
-    theta_params = (e, J, omega_SS.reshape(S, 1), lambdas)
+    theta_params = (e, S, J, omega_SS.reshape(S, 1), lambdas,retire)
     theta = tax.replacement_rate_vals(nssmat, new_w, new_factor, theta_params)
 
     if budget_balance:
@@ -562,13 +562,10 @@ def SS_solver(b_guess_init, n_guess_init, wss, rss, T_Hss, factor_ss, params, ba
 #        raise RuntimeError(err)
 
     BQss = new_BQ
-    theta = np.zeros(J) # zero out payroll taxes since included in tax functions
-    # # theta_params = (e, J, omega_SS.reshape(S, 1), lambdas)
-    # # tax.replacement_rate_vals(nssmat, wss, factor_ss, theta_params)
+    theta_params = (e, S, J, omega_SS.reshape(S, 1), lambdas,retire)
+    theta = tax.replacement_rate_vals(nssmat, wss, factor_ss, theta_params)
 
     # Next 5 lines pulled out of inner_loop where they used to calculate T_H. Now calculating G to balance gov't budget.
-#    theta_params = (e, J, omega_SS.reshape(S, 1), lambdas)
-#    theta = tax.replacement_rate_vals(nssmat, new_w, new_factor, theta_params)
     b_s = np.array(list(np.zeros(J).reshape(1, J)) + list(bssmat[:-1, :]))
     lump_sum_params = (e, lambdas.reshape(1, J), omega_SS.reshape(S, 1), 'SS', etr_params, theta, tau_bq,
                       tau_payroll, h_wealth, p_wealth, m_wealth, retire, T, S, J)

--- a/Python/ogusa/SS.py
+++ b/Python/ogusa/SS.py
@@ -617,7 +617,8 @@ def SS_solver(b_guess_init, n_guess_init, wss, rss, T_Hss, factor_ss, params, ba
     if small_open == False:
         resource_constraint = Yss - (Css + Iss + Gss)
         print 'Yss= ', Yss, '\n', 'Gss= ', Gss, '\n', 'Css= ', Css, '\n', 'Kss = ', Kss, '\n', 'Iss = ', Iss, '\n', 'Lss = ', Lss, '\n', 'Debt service = ', debt_service_ss
-        print 'D/Y:', debt_ss/Yss, 'T/Y:', T_Hss/Yss, 'G/Y:', Gss/Yss, 'Int payments to GDP:', (rss*debt_ss)/Yss
+        print 'D/Y:', debt_ss/Yss, 'T/Y:', T_Hss/Yss, 'G/Y:', Gss/Yss, 'Rev/Y:', revenue_ss/Yss, 'Int payments to GDP:', (rss*debt_ss)/Yss
+        print 'Check SS budget: ', Gss - (np.exp(g_y)*(1+g_n_ss)-1-rss)*debt_ss - revenue_ss + T_Hss
         print 'resource constraint: ', resource_constraint
     else:
         # include term for current account

--- a/Python/ogusa/SS.py
+++ b/Python/ogusa/SS.py
@@ -617,6 +617,7 @@ def SS_solver(b_guess_init, n_guess_init, wss, rss, T_Hss, factor_ss, params, ba
     if small_open == False:
         resource_constraint = Yss - (Css + Iss + Gss)
         print 'Yss= ', Yss, '\n', 'Gss= ', Gss, '\n', 'Css= ', Css, '\n', 'Kss = ', Kss, '\n', 'Iss = ', Iss, '\n', 'Lss = ', Lss, '\n', 'Debt service = ', debt_service_ss
+        print 'D/Y:', debt_ss/Yss, 'T/Y:', T_Hss/Yss, 'G/Y:', Gss/Yss, 'Int payments to GDP:', (rss*debt_ss)/Yss
         print 'resource constraint: ', resource_constraint
     else:
         # include term for current account
@@ -643,11 +644,10 @@ def SS_solver(b_guess_init, n_guess_init, wss, rss, T_Hss, factor_ss, params, ba
         Return dictionary of SS results
     ------------------------------------------------------------------------
     '''
-
     output = {'Kss': Kss, 'bssmat': bssmat, 'Bss': Bss, 'Lss': Lss, 'Css':Css, 'Iss':Iss, 'nssmat': nssmat, 'Yss': Yss,
               'wss': wss, 'rss': rss, 'theta': theta, 'BQss': BQss, 'factor_ss': factor_ss,
               'bssmat_s': bssmat_s, 'cssmat': cssmat, 'bssmat_splus1': bssmat_splus1,
-              'T_Hss': T_Hss, 'revenue_ss': revenue_ss, 'euler_savings': euler_savings,
+              'T_Hss': T_Hss, 'Gss': Gss, 'revenue_ss': revenue_ss, 'euler_savings': euler_savings,
               'euler_labor_leisure': euler_labor_leisure, 'chi_n': chi_n,
               'chi_b': chi_b}
 

--- a/Python/ogusa/parameters.py
+++ b/Python/ogusa/parameters.py
@@ -462,17 +462,17 @@ def get_full_parameters(baseline, guid, user_modifiable, metadata):
     --------------------------------------------------------------------
     '''
     # Model Parameters
-    S = int(80)
-    lambdas = np.array([0.25, 0.25, 0.2, 0.1, 0.1, 0.09, 0.01])
-    J = lambdas.shape[0]
-    T = int(4 * S)
-    BW = int(10)
-
-    # S = int(40)
-    # lambdas = np.array([0.6,0.4])
+    # S = int(80)
+    # lambdas = np.array([0.25, 0.25, 0.2, 0.1, 0.1, 0.09, 0.01])
     # J = lambdas.shape[0]
     # T = int(4 * S)
     # BW = int(10)
+
+    S = int(80)
+    lambdas = np.array([0.6,0.4])
+    J = lambdas.shape[0]
+    T = int(4 * S)
+    BW = int(10)
 
     start_year = 2016
     starting_age = 20

--- a/Python/ogusa/parameters.py
+++ b/Python/ogusa/parameters.py
@@ -506,9 +506,9 @@ def get_full_parameters(baseline, guid, user_modifiable, metadata):
     # Fiscal imbalance parameters. These allow government deficits, debt, and savings.
     alpha_T            = 0.13  # share of GDP that goes to transfers each period.
     alpha_G            = 0.06  # share of GDP of government spending for periods t<tG1
-    tG1                = int(T/5)  # change government spending rule from alpha_G*Y to glide toward SS debt ratio
+    tG1                = 20#int(T/5)  # change government spending rule from alpha_G*Y to glide toward SS debt ratio
     tG2                = int(T*0.8)  # change gov't spending rule with final discrete jump to achieve SS debt ratio
-    rho_G              = 0.1  # 0 < rho_G < 1 is transition speed for periods [tG1, tG2-1]. Lower rho_G => slower convergence.
+    rho_G              = 0.03#0.1  # 0 < rho_G < 1 is transition speed for periods [tG1, tG2-1]. Lower rho_G => slower convergence.
     debt_ratio_ss      = 0.4  # assumed steady-state debt/GDP ratio. Savings would be a negative number.
     initial_debt       = 0.2  # first-period debt/GDP ratio. Savings would be a negative number.
 

--- a/Python/ogusa/parameters.py
+++ b/Python/ogusa/parameters.py
@@ -462,17 +462,17 @@ def get_full_parameters(baseline, guid, user_modifiable, metadata):
     --------------------------------------------------------------------
     '''
     # Model Parameters
-    # S = int(80)
-    # lambdas = np.array([0.25, 0.25, 0.2, 0.1, 0.1, 0.09, 0.01])
-    # J = lambdas.shape[0]
-    # T = int(4 * S)
-    # BW = int(10)
-
     S = int(80)
-    lambdas = np.array([0.6,0.4])
+    lambdas = np.array([0.25, 0.25, 0.2, 0.1, 0.1, 0.09, 0.01])
     J = lambdas.shape[0]
     T = int(4 * S)
     BW = int(10)
+
+    # S = int(40)
+    # lambdas = np.array([0.6,0.4])
+    # J = lambdas.shape[0]
+    # T = int(4 * S)
+    # BW = int(10)
 
     start_year = 2016
     starting_age = 20

--- a/Python/ogusa/parameters.py
+++ b/Python/ogusa/parameters.py
@@ -504,13 +504,13 @@ def get_full_parameters(baseline, guid, user_modifiable, metadata):
     tpi_hh_r           = np.ones(T+S)*ss_hh_r
 
     # Fiscal imbalance parameters. These allow government deficits, debt, and savings.
-    alpha_T            = 0.13  # share of GDP that goes to transfers each period.
-    alpha_G            = 0.06  # share of GDP of government spending for periods t<tG1
+    alpha_T            = 0.09 #0.13  # share of GDP that goes to transfers each period.
+    alpha_G            = 0.05 #0.06  # share of GDP of government spending for periods t<tG1
     tG1                = 20#int(T/5)  # change government spending rule from alpha_G*Y to glide toward SS debt ratio
     tG2                = int(T*0.8)  # change gov't spending rule with final discrete jump to achieve SS debt ratio
     rho_G              = 0.03#0.1  # 0 < rho_G < 1 is transition speed for periods [tG1, tG2-1]. Lower rho_G => slower convergence.
     debt_ratio_ss      = 0.4  # assumed steady-state debt/GDP ratio. Savings would be a negative number.
-    initial_debt       = 0.2  # first-period debt/GDP ratio. Savings would be a negative number.
+    initial_debt       = 0.59 #0.2  # first-period debt/GDP ratio. Savings would be a negative number.
 
     if tG1 > tG2:
         print 'The first government spending rule change date, (', tG1, ') is after the second one (', tG2, ').'

--- a/Python/ogusa/tax.py
+++ b/Python/ogusa/tax.py
@@ -35,41 +35,29 @@ def replacement_rate_vals(nssmat, wss, factor_ss, params):
         theta      = [J,] vector, replacement rates by lifetime income group
     Returns: theta
     '''
-    e, J, omega_SS, lambdas = params
-
-    # Do a try/except, depending on whether the arrays are 1 or 2 dimensional
-    try:
-        AIME = ((wss * factor_ss * e * nssmat) *
-                omega_SS).sum(0) * lambdas / 12.0
-        PIA = np.zeros(J)
-        # Bins from data for each level of replacement
-        for j in xrange(J):
-            if AIME[j] < 749.0:
-                PIA[j] = .9 * AIME[j]
-            elif AIME[j] < 4517.0:
-                PIA[j] = 674.1 + .32 * (AIME[j] - 749.0)
-            else:
-                PIA[j] = 1879.86 + .15 * (AIME[j] - 4517.0)
-        theta = PIA * (e * nssmat).mean(0) / AIME
-        # Set the maximum replacment rate to be $30,000
-        maxpayment = 30000.0 / (factor_ss * wss)
-        theta[theta > maxpayment] = maxpayment
-    except:
-        AIME = ((wss * factor_ss * e * nssmat) *
-                omega_SS).sum() * lambdas / 12.0
-        PIA = 0
-        if AIME < 749.0:
-            PIA = .9 * AIME
-        elif AIME < 4517.0:
-            PIA = 674.1 + .32 * (AIME - 749.0)
+    e, S, J, omega_SS, lambdas, retire = params
+    dim2 = 1
+    if nssmat.ndim==2:
+        dim2 = J
+    start_last_35 = retire-int(round((S/80)*35))
+    AIME = (e *(wss * nssmat * factor_ss).reshape(S,dim2))[start_last_35:retire,:].sum(0) / ((12.0*(S/80))*int(round((S/80)*35)))
+    # try:
+    #     AIME = (e *(wss * nssmat * factor_ss).reshape(S,1))[start_last_35:retire,:].sum(0) / ((12.0*(S/80))*int(round((S/80)*35)))
+    # except:
+    #     AIME = (e *(wss * nssmat * factor_ss).reshape(S,J))[start_last_35:retire,:].sum(0) / ((12.0*(S/80))*int(round((S/80)*35)))
+    PIA = np.zeros(J)
+    # Bins from data for each level of replacement
+    for j in xrange(J):
+        if AIME[j] < 749.0:
+            PIA[j] = .9 * AIME[j]
+        elif AIME[j] < 4517.0:
+            PIA[j] = 674.1 + .32 * (AIME[j] - 749.0)
         else:
-            PIA = 1879.86 + .15 * (AIME - 4517.0)
-        theta = PIA * (e * nssmat).mean(0) / AIME
-        # Set the maximum replacment rate to be $30,000
-        maxpayment = 30000.0 / (factor_ss * wss)
-        if theta > maxpayment:
-            theta = maxpayment
-    theta = 0  # setting theta = 0 since we are including social security income in capital income (CHECK)
+            PIA[j] = 1879.86 + .15 * (AIME[j] - 4517.0)
+    # Set the maximum replacment rate to be $30,000
+    maxpayment = 30000.0
+    PIA[PIA > maxpayment] = maxpayment
+    theta = (PIA*(12.0*S/80)) / (factor_ss*wss)
     return theta
 
 

--- a/Python/ogusa/tax.py
+++ b/Python/ogusa/tax.py
@@ -39,12 +39,10 @@ def replacement_rate_vals(nssmat, wss, factor_ss, params):
     dim2 = 1
     if nssmat.ndim==2:
         dim2 = J
-    start_last_35 = retire-int(round((S/80)*35))
-    AIME = (e *(wss * nssmat * factor_ss).reshape(S,dim2))[start_last_35:retire,:].sum(0) / ((12.0*(S/80))*int(round((S/80)*35)))
-    # try:
-    #     AIME = (e *(wss * nssmat * factor_ss).reshape(S,1))[start_last_35:retire,:].sum(0) / ((12.0*(S/80))*int(round((S/80)*35)))
-    # except:
-    #     AIME = (e *(wss * nssmat * factor_ss).reshape(S,J))[start_last_35:retire,:].sum(0) / ((12.0*(S/80))*int(round((S/80)*35)))
+    # get highest earning 35 years
+    earnings = (e *(wss * nssmat * factor_ss).reshape(S,dim2))
+    highest_35_earn = -1.0*np.partition(-earnings, int(round((S/80)*35)),axis=0)
+    AIME = highest_35_earn.sum(0) / ((12.0*(S/80))*int(round((S/80)*35)))
     PIA = np.zeros(J)
     # Bins from data for each level of replacement
     for j in xrange(J):
@@ -55,7 +53,7 @@ def replacement_rate_vals(nssmat, wss, factor_ss, params):
         else:
             PIA[j] = 1879.86 + .15 * (AIME[j] - 4517.0)
     # Set the maximum replacment rate to be $30,000
-    maxpayment = 30000.0
+    maxpayment = 3501.00 #30000.0/12.0
     PIA[PIA > maxpayment] = maxpayment
     theta = (PIA*(12.0*S/80)) / (factor_ss*wss)
     return theta

--- a/Python/run_ogusa_serial.py
+++ b/Python/run_ogusa_serial.py
@@ -45,7 +45,7 @@ def run_micro_macro(user_params):
     BASELINE_DIR = "./OUTPUT_BASELINE"
 
 
-    user_params = {'frisch':0.41, 'start_year':2016, 'debt_ratio_ss':0.4}
+    user_params = {'frisch':0.41, 'start_year':2016, 'debt_ratio_ss':1.0}
 
     '''
     ------------------------------------------------------------------------

--- a/Python/run_ogusa_serial.py
+++ b/Python/run_ogusa_serial.py
@@ -52,16 +52,16 @@ def run_micro_macro(user_params):
         Run SS for Baseline first - so can run baseline and reform in parallel if want
     ------------------------------------------------------------------------
     '''
-    output_base = BASELINE_DIR
-    input_dir = BASELINE_DIR
-    kwargs={'output_base':output_base, 'baseline_dir':BASELINE_DIR,
-           'baseline':True, 'analytical_mtrs':False, 'age_specific':True,
-           'user_params':user_params,'guid':'test',
-           'run_micro':False, 'small_open':False, 'budget_balance':False}
-    #p1 = Process(target=runner, kwargs=kwargs)
-    #p1.start()
-    runner_SS(**kwargs)
-    quit()
+    # output_base = BASELINE_DIR
+    # input_dir = BASELINE_DIR
+    # kwargs={'output_base':output_base, 'baseline_dir':BASELINE_DIR,
+    #        'baseline':True, 'analytical_mtrs':False, 'age_specific':True,
+    #        'user_params':user_params,'guid':'test',
+    #        'run_micro':False, 'small_open':False, 'budget_balance':False}
+    # #p1 = Process(target=runner, kwargs=kwargs)
+    # #p1.start()
+    # runner_SS(**kwargs)
+    # quit()
 
 
     '''


### PR DESCRIPTION
This PR fixes the calibration of the `theta` parameter, which determines the social security replacement rate.

@rickecon and @kerkphil - can you take a look at the `tax.replacement_rate_vals()` function to see if this approach to calibrating `theta` seems right?

This PR is a work in progress because with the current calibration of `theta`, the model is able to find a solution for the case of per period balanced budgets, but can only solve of the SS (not the TP) when the budget is unbalanced.  I'm not sure of why this is, but the TPI cycles and does not converge.  