### PR TITLE
Remove passing growth assumptions to taxcalc

### DIFF
--- a/Python/ogusa/get_micro_data.py
+++ b/Python/ogusa/get_micro_data.py
@@ -28,37 +28,6 @@ import copy
 import numba
 import pickle
 
-def only_growth_assumptions(user_mods, start_year):
-    """
-    Extract any reform parameters that are pertinent to growth
-    assumptions
-    """
-    growth_dd = taxcalc.growth.Growth.default_data(start_year=start_year)
-    ga = {}
-    for year, reforms in user_mods.items():
-        overlap = set(growth_dd.keys()) & set(reforms.keys())
-        if overlap:
-            ga[year] = {param:reforms[param] for param in overlap}
-    return ga
-
-
-def only_reform_mods(user_mods, start_year):
-    """
-    Extract parameters that are just for policy reforms
-    """
-    pol_refs = {}
-    beh_dd = Behavior.default_data(start_year=start_year)
-    growth_dd = taxcalc.growth.Growth.default_data(start_year=start_year)
-    policy_dd = taxcalc.policy.Policy.default_data(start_year=start_year)
-    for year, reforms in user_mods.items():
-        all_cpis = {p for p in reforms.keys() if p.endswith("_cpi") and
-                    p[:-4] in policy_dd.keys()}
-        pols = set(reforms.keys()) - set(beh_dd.keys()) - set(growth_dd.keys())
-        pols &= set(policy_dd.keys())
-        pols ^= all_cpis
-        if pols:
-            pol_refs[year] = {param:reforms[param] for param in pols}
-    return pol_refs
 
 def get_calculator(baseline, calculator_start_year, reform=None, data=None, weights=None, records_start_year=None):
     '''
@@ -89,17 +58,11 @@ def get_calculator(baseline, calculator_start_year, reform=None, data=None, weig
         #Should not be a reform if baseline is True
         assert not reform
 
-    growth_assumptions = only_growth_assumptions(reform, calculator_start_year)
-    reform_mods = only_reform_mods(reform, calculator_start_year)
-
     if not baseline:
-        policy1.implement_reform(reform_mods)
+        policy1.implement_reform(reform)
 
     # the default set up increments year to 2013
     calc1 = Calculator(records=records1, policy=policy1)
-
-    if growth_assumptions:
-        calc1.growth.update_growth(growth_assumptions)
 
     # this increment_year function extrapolates all PUF variables to the next year
     # so this step takes the calculator to the start_year

--- a/Python/ogusa/tests/test_basic.py
+++ b/Python/ogusa/tests/test_basic.py
@@ -177,7 +177,7 @@ def test_compare_dict_diff_ndarrays_relative():
 def test_get_micro_data_get_calculator():
 
     reform = {
-    2016: {
+    2017: {
         '_II_rt1': [.09],
         '_II_rt2': [.135],
         '_II_rt3': [.225],
@@ -187,24 +187,23 @@ def test_get_micro_data_get_calculator():
         '_II_rt7': [0.3564],
     }, }
 
-    calc = get_calculator(baseline=False, calculator_start_year=2016,
+    calc = get_calculator(baseline=False, calculator_start_year=2017,
                           reform=reform, data=TAXDATA,
                           weights=WEIGHTS, records_start_year=2009)
-    assert calc.current_year == 2016
+    assert calc.current_year == 2017
 
     reform = {
-    2016: {
+    2017: {
         '_II_rt1': [.09],
         '_II_rt2': [.135],
         '_II_rt3': [.225],
         '_II_rt4': [.252],
         '_II_rt5': [.297],
         '_II_rt6': [.315],
-        '_II_rt7': [0.3564],
-        '_factor_adjustment': [0.1]
+        '_II_rt7': [0.3564]
     }, }
 
-    calc2 = get_calculator(baseline=False, calculator_start_year=2016,
+    calc2 = get_calculator(baseline=False, calculator_start_year=2017,
                            reform=reform, data=TAXDATA,
                            weights=WEIGHTS, records_start_year=2009)
-    assert calc2.current_year == 2016
+    assert calc2.current_year == 2017

--- a/Python/ogusa/tests/test_run_ogusa.py
+++ b/Python/ogusa/tests/test_run_ogusa.py
@@ -73,7 +73,7 @@ def run_micro_macro(reform, user_params, guid):
 def test_run_micro_macro():
 
     reform = {
-    2016: {
+    2017: {
         '_II_rt1': [.09],
         '_II_rt2': [.135],
         '_II_rt3': [.225],

--- a/Python/run_ogusa_serial.py
+++ b/Python/run_ogusa_serial.py
@@ -74,7 +74,7 @@ def run_micro_macro(user_params):
     kwargs={'output_base':output_base, 'baseline_dir':BASELINE_DIR,
             'test':True, 'time_path':True, 'baseline':True, 'analytical_mtrs':False, 'age_specific':True,
             'user_params':user_params,'guid':'',
-            'run_micro':True, 'small_open': False, 'budget_balance':False}
+            'run_micro':False, 'small_open': False, 'budget_balance':False}
     #p1 = Process(target=runner, kwargs=kwargs)
     #p1.start()
     runner(**kwargs)

--- a/Python/run_ogusa_serial.py
+++ b/Python/run_ogusa_serial.py
@@ -74,7 +74,7 @@ def run_micro_macro(user_params):
     kwargs={'output_base':output_base, 'baseline_dir':BASELINE_DIR,
             'test':True, 'time_path':True, 'baseline':True, 'analytical_mtrs':False, 'age_specific':True,
             'user_params':user_params,'guid':'',
-            'run_micro':False, 'small_open': False, 'budget_balance':False}
+            'run_micro':True, 'small_open': False, 'budget_balance':False}
     #p1 = Process(target=runner, kwargs=kwargs)
     #p1.start()
     runner(**kwargs)


### PR DESCRIPTION
This PR removes the passing of growth assumptions defined by the OG-USA user to the Tax Calculator.  This makes OG-USA compatible with TaxCalc 0.7.7.

Note that this passing of the exogenous long run growth rate from OG-USA to Tax Calc was not the correct mapping between the growth parameters of the two models.  If one wants to correctly pass growth rates from OG-USA to Tax Calc, one would need to first solve the OG-USA model to recover the endogenous growth rates over the budget window period.  Further, to be consistent, one would need to iterate between the Tax Calc and OG-USA to ensure that the growth rates are consistent with the tax functions derive from Tax Calc with those growth assumptions.