### PR TITLE
Fixing error in Reform SS argument passing

### DIFF
--- a/Python/execute.py
+++ b/Python/execute.py
@@ -46,7 +46,7 @@ def runner(output_base, baseline_dir, test=False, time_path=True, baseline=False
 
     # Modify ogusa parameters based on user input
     if 'frisch' in user_params:
-        print "updating fricsh and associated"
+        print "updating frisch and associated"
         b_ellipse, upsilon = ogusa.elliptical_u_est.estimation(user_params['frisch'],
                                                                run_params['ltilde'])
         run_params['b_ellipse'] = b_ellipse

--- a/Python/ogusa/SS.py
+++ b/Python/ogusa/SS.py
@@ -320,7 +320,7 @@ def inner_loop(outer_loop_vars, params, baseline):
                                    args=euler_params, xtol=MINIMIZER_TOL, full_output=True)
 
         euler_errors[:,j] = infodict['fvec']
-        print 'Max Euler errors: ', np.absolute(euler_errors[:,j]).max()
+#        print 'Max Euler errors: ', np.absolute(euler_errors[:,j]).max()
 
         bssmat[:, j] = solutions[:S]
         nssmat[:, j] = solutions[S:]
@@ -789,8 +789,6 @@ def SS_fsolve_reform(guesses, params):
     w = guesses[1]
     T_H = guesses[2]
 
-    print 'Reform SS factor is: ', factor
-
     # Solve for the steady state levels of b and n, given w, r, T_H and
     # factor
     if budget_balance:
@@ -809,8 +807,8 @@ def SS_fsolve_reform(guesses, params):
         error3 = new_T_H - T_H
     else:
         error3 = new_Y - Y
-    print 'errors: ', error1, error2, error3
-    print 'factor prices: ', r, w
+#    print 'errors: ', error1, error2, error3
+#    print 'factor prices: ', r, w
 
     # Check and punish violations
     if r <= 0:
@@ -903,7 +901,7 @@ def run_SS(income_tax_params, ss_params, iterative_params, chi_params, small_ope
         baseline_ss_dir = os.path.join(
             baseline_dir, "SS/SS_vars.pkl")
         ss_solutions = pickle.load(open(baseline_ss_dir, "rb"))
-        [rguess, wguess, T_Hguess, factor] = [ss_solutions['wss'], ss_solutions['rss'], ss_solutions['T_Hss'], ss_solutions['factor_ss']]
+        [wguess, rguess, T_Hguess, factor] = [ss_solutions['wss'], ss_solutions['rss'], ss_solutions['T_Hss'], ss_solutions['factor_ss']]
         ss_params_reform = [b_guess.reshape(S, J), n_guess.reshape(S, J), chi_params, ss_params, income_tax_params, iterative_params, factor, small_open_params]
         guesses = [rguess, wguess, T_Hguess]
         [solutions_fsolve, infodict, ier, message] = opt.fsolve(SS_fsolve_reform, guesses, args=ss_params_reform, xtol=mindist_SS, full_output=True)

--- a/Python/ogusa/SS.py
+++ b/Python/ogusa/SS.py
@@ -901,7 +901,7 @@ def run_SS(income_tax_params, ss_params, iterative_params, chi_params, small_ope
         baseline_ss_dir = os.path.join(
             baseline_dir, "SS/SS_vars.pkl")
         ss_solutions = pickle.load(open(baseline_ss_dir, "rb"))
-        [wguess, rguess, T_Hguess, factor] = [ss_solutions['wss'], ss_solutions['rss'], ss_solutions['T_Hss'], ss_solutions['factor_ss']]
+        [rguess, wguess, T_Hguess, factor] = [ss_solutions['rss'], ss_solutions['wss'], ss_solutions['T_Hss'], ss_solutions['factor_ss']]
         ss_params_reform = [b_guess.reshape(S, J), n_guess.reshape(S, J), chi_params, ss_params, income_tax_params, iterative_params, factor, small_open_params]
         guesses = [rguess, wguess, T_Hguess]
         [solutions_fsolve, infodict, ier, message] = opt.fsolve(SS_fsolve_reform, guesses, args=ss_params_reform, xtol=mindist_SS, full_output=True)

--- a/Python/run_ogusa_serial.py
+++ b/Python/run_ogusa_serial.py
@@ -78,7 +78,7 @@ def run_micro_macro(user_params):
     #p1 = Process(target=runner, kwargs=kwargs)
     #p1.start()
     runner(**kwargs)
-    quit()
+#    quit()
 
     '''
     ------------------------------------------------------------------------
@@ -89,9 +89,9 @@ def run_micro_macro(user_params):
 #    input_dir = REFORM_DIR
 #    guid_iter = 'reform_' + str(0)
 #    kwargs={'output_base':output_base, 'baseline_dir':BASELINE_DIR,
-#            'baseline':False, 'analytical_mtrs':False, 'age_specific':False,
-#            'user_params':user_params,'guid':'_alt',
-#            'reform':reform , 'run_micro':False, 'small_open': True}
+#            'test':True, 'time_path':True, 'baseline':False, 'analytical_mtrs':False, 'age_specific':True,
+#            'user_params':user_params,'guid':'', 'reform':reform , 
+#            'run_micro':False, 'small_open': False, 'budget_balance':False}
 #    #p2 = Process(target=runner, kwargs=kwargs)
 #    #p2.start()
 #    runner(**kwargs)


### PR DESCRIPTION
In SS.run_SS, there's an errant line of code for the baseline==False option:
`[rguess, wguess, T_Hguess, factor] = [ss_solutions['wss'], ss_solutions['rss'], ss_solutions['T_Hss'], ss_solutions['factor_ss']]`

Note that `ss_solutions['wss']` is being assigned to `rguess` and vice versa. This pull request fixes this line to read:

`[wguess, rguess, T_Hguess, factor] = [ss_solutions['wss'], ss_solutions['rss'], ss_solutions['T_Hss'], ss_solutions['factor_ss']]
`

This pull request also regularizes the `kwargs` in the (still-commented) Run Reform section so that they match the baseline. This helps avoid unforced errors, like running Baseline as an open economy and Reform as a closed economy.