### PR TITLE
lower TPI tolerance

### DIFF
--- a/Python/ogusa/parameters.py
+++ b/Python/ogusa/parameters.py
@@ -292,7 +292,7 @@ def get_parameters(test=False, baseline=False, guid='', user_modifiable=False, m
         PLOT_TPI = False
         maxiter = 250
         mindist_SS = 1e-9
-        mindist_TPI =  1e-9
+        mindist_TPI =  1e-6
         nu = .4
         flag_graphs = False
 


### PR DESCRIPTION
The PR changes the tolerance for convergence in the TPI solution from 1e-9 to 1e-6.  We may tighten this up again in the future, but this will help with some regression testing.

