### PR TITLE
fix numpy and pandas versions

### DIFF
--- a/Python/conda.recipe/meta.yaml
+++ b/Python/conda.recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
 requirements:
   build:
     - matplotlib
-    - numpy
-    - pandas
+    - numpy >=1.12.1
+    - pandas >=0.20.1
     - pytest
     - python
     - scipy
@@ -15,8 +15,8 @@ requirements:
 
   run:
     - matplotlib
-    - numpy
-    - pandas
+    - numpy >=1.12.1
+    - pandas >=0.20.1
     - pytest
     - python
     - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
 - taxcalc
 - numba
 - numpy
-- pandas=0.16.1
+- numpy >=1.12.1
+- pandas >=0.20.1
 - pytest
 - python=2.7


### PR DESCRIPTION
Fix B-Tax numpy and pandas versions to be like `taxcalc=0.8.4` - See also [Tax-Calculator Issue 
 31](https://github.com/open-source-economics/policybrain-builder/issues/31) and [B-Tax PR](https://github.com/open-source-economics/B-Tax/pull/161)