### PR TITLE
Remove taxcalc version hard coding from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pytest nomkl scipy=0.18.1 numpy=1.11.2 pandas=0.18.0 matplotlib
-  - conda install -n test-environment -c ospc taxcalc=0.8.3
+  - conda env update -f environment.yml
   - conda install -n test-environment numba
   - source activate test-environment
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
-  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pytest nomkl scipy=0.18.1 numpy=1.11.2 pandas=0.18.0 matplotlib
+  - conda create -n ospcdyn python=$TRAVIS_PYTHON_VERSION
+  - source activate ospcdyn
   - conda env update -f environment.yml
-  - conda install -n test-environment numba
-  - source activate test-environment
   - python setup.py install
 
 


### PR DESCRIPTION
Closes #326.  Solution copied from the [Tax-Calculator .travis.yml.](https://github.com/open-source-economics/Tax-Calculator/blob/master/.travis.yml#L17)