### PR TITLE
Progressive vs constant rates

### DIFF
--- a/ogusa/get_micro_data.py
+++ b/ogusa/get_micro_data.py
@@ -27,6 +27,7 @@ import numpy as np
 import copy
 import numba
 import pickle
+from ogusa.utils import DEFAULT_START_YEAR
 
 
 def get_calculator(baseline, calculator_start_year, reform=None, data=None,
@@ -78,7 +79,7 @@ def get_calculator(baseline, calculator_start_year, reform=None, data=None,
     return calc1
 
 
-def get_data(baseline=False, start_year=2018, reform={}, data=None):
+def get_data(baseline=False, start_year=DEFAULT_START_YEAR, reform={}, data=None):
     '''
     --------------------------------------------------------------------
     This function creates dataframes of micro data from the

--- a/ogusa/parameters.py
+++ b/ogusa/parameters.py
@@ -396,16 +396,16 @@ def get_parameters(test=False, baseline=False, guid='', user_modifiable=False, m
     mtry_params = dict_params['tfunc_mtry_params_S'][:S,:BW,:]
 
     # # Make all ETRs equal the average
-    # etr_params = np.zeros(etr_params.shape)
-    # etr_params[:, :, 10] = dict_params['tfunc_avg_etr'] # set shift to average rate
+    etr_params = np.zeros(etr_params.shape)
+    etr_params[:, :, 10] = dict_params['tfunc_avg_etr'] # set shift to average rate
 
     # # Make all MTRx equal the average
-    # mtrx_params = np.zeros(mtrx_params.shape)
-    # mtrx_params[:, :, 10] = dict_params['tfunc_avg_mtrx'] # set shift to average rate
+    mtrx_params = np.zeros(mtrx_params.shape)
+    mtrx_params[:, :, 10] = dict_params['tfunc_avg_mtrx'] # set shift to average rate
 
     # # Make all MTRy equal the average
-    # mtry_params = np.zeros(mtry_params.shape)
-    # mtry_params[:, :, 10] = dict_params['tfunc_avg_mtry'] # set shift to average rate
+    mtry_params = np.zeros(mtry_params.shape)
+    mtry_params[:, :, 10] = dict_params['tfunc_avg_mtry'] # set shift to average rate
 
     # # Make MTRx depend only on labor income
     # mtrx_params[:, :, 11] = 1.0 # set share parameter to 1

--- a/ogusa/parameters.py
+++ b/ogusa/parameters.py
@@ -33,7 +33,7 @@ import pickle
 import txfunc
 import elliptical_u_est as ellip
 import matplotlib.pyplot as plt
-
+from ogusa.utils import DEFAULT_START_YEAR
 
 '''
 ------------------------------------------------------------------------
@@ -137,7 +137,7 @@ def get_parameters_from_file():
 
 
 def get_parameters(test=False, baseline=False, guid='', user_modifiable=False, metadata=False,
-                   tx_func_est_path=None, start_year=2018):
+                   tx_func_est_path=None, start_year=DEFAULT_START_YEAR):
     '''
     --------------------------------------------------------------------
     This function returns the model parameters.
@@ -396,16 +396,16 @@ def get_parameters(test=False, baseline=False, guid='', user_modifiable=False, m
     mtry_params = dict_params['tfunc_mtry_params_S'][:S,:BW,:]
 
     # # Make all ETRs equal the average
-    etr_params = np.zeros(etr_params.shape)
-    etr_params[:, :, 10] = dict_params['tfunc_avg_etr'] # set shift to average rate
+    # etr_params = np.zeros(etr_params.shape)
+    # etr_params[:, :, 10] = dict_params['tfunc_avg_etr'] # set shift to average rate
 
     # # Make all MTRx equal the average
-    mtrx_params = np.zeros(mtrx_params.shape)
-    mtrx_params[:, :, 10] = dict_params['tfunc_avg_mtrx'] # set shift to average rate
+    # mtrx_params = np.zeros(mtrx_params.shape)
+    # mtrx_params[:, :, 10] = dict_params['tfunc_avg_mtrx'] # set shift to average rate
 
     # # Make all MTRy equal the average
-    mtry_params = np.zeros(mtry_params.shape)
-    mtry_params[:, :, 10] = dict_params['tfunc_avg_mtry'] # set shift to average rate
+    # mtry_params = np.zeros(mtry_params.shape)
+    # mtry_params[:, :, 10] = dict_params['tfunc_avg_mtry'] # set shift to average rate
 
     # # Make MTRx depend only on labor income
     # mtrx_params[:, :, 11] = 1.0 # set share parameter to 1

--- a/ogusa/parameters.py
+++ b/ogusa/parameters.py
@@ -136,8 +136,10 @@ def get_parameters_from_file():
         return j
 
 
-def get_parameters(test=False, baseline=False, guid='', user_modifiable=False, metadata=False,
-                   tx_func_est_path=None, start_year=DEFAULT_START_YEAR):
+def get_parameters(test=False, baseline=False, guid='',
+                   user_modifiable=False, metadata=False,
+                   tx_func_est_path=None, start_year=DEFAULT_START_YEAR,
+                   constant_rates=True):
     '''
     --------------------------------------------------------------------
     This function returns the model parameters.
@@ -395,17 +397,19 @@ def get_parameters(test=False, baseline=False, guid='', user_modifiable=False, m
     mtrx_params = dict_params['tfunc_mtrx_params_S'][:S,:BW,:]
     mtry_params = dict_params['tfunc_mtry_params_S'][:S,:BW,:]
 
-    # # Make all ETRs equal the average
-    etr_params = np.zeros(etr_params.shape)
-    etr_params[:, :, 10] = dict_params['tfunc_avg_etr'] # set shift to average rate
+    if constant_rates:
+        print 'USINGconstant rates!'
+        # # Make all ETRs equal the average
+        etr_params = np.zeros(etr_params.shape)
+        etr_params[:, :, 10] = dict_params['tfunc_avg_etr'] # set shift to average rate
 
-    # # Make all MTRx equal the average
-    mtrx_params = np.zeros(mtrx_params.shape)
-    mtrx_params[:, :, 10] = dict_params['tfunc_avg_mtrx'] # set shift to average rate
+        # # Make all MTRx equal the average
+        mtrx_params = np.zeros(mtrx_params.shape)
+        mtrx_params[:, :, 10] = dict_params['tfunc_avg_mtrx'] # set shift to average rate
 
-    # # Make all MTRy equal the average
-    mtry_params = np.zeros(mtry_params.shape)
-    mtry_params[:, :, 10] = dict_params['tfunc_avg_mtry'] # set shift to average rate
+        # # Make all MTRy equal the average
+        mtry_params = np.zeros(mtry_params.shape)
+        mtry_params[:, :, 10] = dict_params['tfunc_avg_mtry'] # set shift to average rate
 
     # # Make MTRx depend only on labor income
     # mtrx_params[:, :, 11] = 1.0 # set share parameter to 1

--- a/ogusa/scripts/execute.py
+++ b/ogusa/scripts/execute.py
@@ -16,9 +16,9 @@ from ogusa.utils import DEFAULT_START_YEAR
 
 
 def runner(output_base, baseline_dir, test=False, time_path=True,
-           baseline=False, analytical_mtrs=False, age_specific=False,
-           reform={}, user_params={}, guid='', run_micro=True,
-           small_open=False, budget_balance=False,
+           baseline=False, constant_rates=True, analytical_mtrs=False,
+           age_specific=False, reform={}, user_params={}, guid='',
+           run_micro=True, small_open=False, budget_balance=False,
            baseline_spending=False, data=None):
 
     from ogusa import parameters, demographics, income, utils
@@ -64,8 +64,8 @@ def runner(output_base, baseline_dir, test=False, time_path=True,
         test=test, baseline=baseline, guid=guid,
         start_year=user_params.get('start_year', DEFAULT_START_YEAR),
         tx_func_est_path=os.path.join(
-            output_base,'TxFuncEst_{}.pkl'.format(guid)
-        )
+            output_base,'TxFuncEst_{}.pkl'.format(guid),
+        ), constant_rates=True
     )
     run_params['analytical_mtrs'] = analytical_mtrs
     run_params['small_open'] = small_open

--- a/ogusa/scripts/execute.py
+++ b/ogusa/scripts/execute.py
@@ -11,6 +11,7 @@ import time
 import ogusa
 from ogusa import calibrate
 ogusa.parameters.DATASET = 'REAL'
+from ogusa.utils import DEFAULT_START_YEAR
 
 
 
@@ -51,7 +52,7 @@ def runner(output_base, baseline_dir, test=False, time_path=True,
         txfunc.get_tax_func_estimate(
             baseline=baseline, analytical_mtrs=analytical_mtrs,
             age_specific=age_specific,
-            start_year=user_params.get('start_year', 2018),
+            start_year=user_params.get('start_year', DEFAULT_START_YEAR),
             reform=reform, guid=guid,
             tx_func_est_path=os.path.join(
                 output_base,'TxFuncEst_{}.pkl'.format(guid)
@@ -61,7 +62,7 @@ def runner(output_base, baseline_dir, test=False, time_path=True,
     print 'In runner, baseline is ', baseline
     run_params = ogusa.parameters.get_parameters(
         test=test, baseline=baseline, guid=guid,
-        start_year=user_params.get('start_year', 2018),
+        start_year=user_params.get('start_year', DEFAULT_START_YEAR),
         tx_func_est_path=os.path.join(
             output_base,'TxFuncEst_{}.pkl'.format(guid)
         )

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -44,6 +44,7 @@ from matplotlib import cm
 
 import get_micro_data
 import utils
+from utils import DEFAULT_START_YEAR
 
 TAX_ESTIMATE_PATH = os.environ.get("TAX_ESTIMATE_PATH", ".")
 
@@ -1546,7 +1547,7 @@ def tax_func_estimate(beg_yr=2016, baseline=True, analytical_mtrs=False,
 
 
 def get_tax_func_estimate(baseline=False, analytical_mtrs=False,
-                          age_specific=False, start_year=2018, reform={},
+                          age_specific=False, start_year=DEFAULT_START_YEAR, reform={},
                           guid='', tx_func_est_path=None, data=None):
     '''
     --------------------------------------------------------------------

--- a/ogusa/utils.py
+++ b/ogusa/utils.py
@@ -23,6 +23,9 @@ PATH_EXISTS_ERRNO = 17
 REFORM_DIR = "./OUTPUT_REFORM"
 BASELINE_DIR = "./OUTPUT_BASELINE"
 
+# Default year for model runs
+DEFAULT_START_YEAR = 2018
+
 # for f in (REFORM_DIR, BASELINE_DIR):
 #     if not os.path.exists(f):
 #         os.mkdir(f)


### PR DESCRIPTION
This PR adds a boolean keyword argument for selecting either constant ATRs and MTRs and the progressive tax functions estimated from the Tax-Calculator output.  Previously we had just been switching between the two by manually commenting out lines of code. 

cc @rickecon 