### PR TITLE
Add Gss warning

### DIFF
--- a/ogusa/SS.py
+++ b/ogusa/SS.py
@@ -28,6 +28,7 @@ from . import aggregates as aggr
 import firm
 import utils
 import os
+import warnings
 
 
 '''
@@ -1138,6 +1139,12 @@ def run_SS(income_tax_params, ss_params, iterative_params, chi_params,
             # budget_balance = True, but that's ok - will be fixed in SS_solver
         if ENFORCE_SOLUTION_CHECKS and not ier == 1:
             raise RuntimeError("Steady state equilibrium not found")
+        if output['Gss'] < 0.:
+            warnings.warn('Warning: The combination of the tax policy '
+                          + 'you specified and your target debt-to-GDP '
+                          + 'ratio results in an infeasible amount of '
+                          + 'government spending in order to close the '
+                          + 'budget (i.e., G < 0)')
         # Return SS values of variables
         fsolve_flag = True
         # Return SS values of variables

--- a/ogusa/SS.py
+++ b/ogusa/SS.py
@@ -1139,12 +1139,6 @@ def run_SS(income_tax_params, ss_params, iterative_params, chi_params,
             # budget_balance = True, but that's ok - will be fixed in SS_solver
         if ENFORCE_SOLUTION_CHECKS and not ier == 1:
             raise RuntimeError("Steady state equilibrium not found")
-        if output['Gss'] < 0.:
-            warnings.warn('Warning: The combination of the tax policy '
-                          + 'you specified and your target debt-to-GDP '
-                          + 'ratio results in an infeasible amount of '
-                          + 'government spending in order to close the '
-                          + 'budget (i.e., G < 0)')
         # Return SS values of variables
         fsolve_flag = True
         # Return SS values of variables
@@ -1154,4 +1148,10 @@ def run_SS(income_tax_params, ss_params, iterative_params, chi_params,
         output = SS_solver(b_guess.reshape(S, J), n_guess.reshape(S, J),
                            rss, T_Hss, factor, Yss, solution_params,
                            baseline, fsolve_flag, baseline_spending)
+        if output['Gss'] < 0.:
+            warnings.warn('Warning: The combination of the tax policy '
+                          + 'you specified and your target debt-to-GDP '
+                          + 'ratio results in an infeasible amount of '
+                          + 'government spending in order to close the '
+                          + 'budget (i.e., G < 0)')
     return output


### PR DESCRIPTION
This PR replaces PR #319 and adds a warning message if government spending is forced negative to balance the budget in the steady-state.  The model solves, but the user is notified of this condition.