### PR TITLE
Initial debt

### DIFF
--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -548,34 +548,6 @@ def inner_loop(guesses, outer_loop_vars, params):
     return euler_errors, b_mat, n_mat
 
 
-def initial_GDP_level(y_guess, gamma, epsilon, Z, initial_debt, B, L):
-    '''
-    Solve for first-period output given debt ratio, wealth, labor input,
-    and production function.
-
-    The solution arises from a 3-unknown, 3-equation system that is
-    simplified below.
-    (1) initial_debt = D/Y by assumption.
-    (2) Y = f(K,L)
-    (3) K = B - D, where B is household wealth
-    This could easily be modified to allow for an initial level of
-    foreign bondholding.
-    '''
-    if epsilon == 1:
-        error = y_guess - Z*((B - initial_debt*y_guess)**gamma)*(L**(1-gamma))
-    elif epsilon == 0:
-        error = y_guess - Z*(gamma*(B - initial_debt*y_guess) + (1-gamma)*L)
-    else:
-        error = y_guess - (Z * (((gamma ** (1 / epsilon)) *
-                                 ((B - initial_debt * y_guess) **
-                                  ((epsilon - 1) / epsilon))) +
-                                (((1 - gamma) ** (1 / epsilon)) *
-                                 (L ** ((epsilon - 1) / epsilon)))) **
-                           (epsilon / (epsilon - 1)))
-
-    return error
-
-
 def run_TPI(income_tax_params, tpi_params, iterative_params,
             small_open_params, initial_values, SS_values, fiscal_params,
             biz_tax_params, output_dir="./OUTPUT",

--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -760,7 +760,7 @@ def run_TPI(income_tax_params, tpi_params, iterative_params,
                 if baseline:
                     D_0 = initial_debt * Y[0]
                 else:
-                    B_0 = D0
+                    D_0 = D0
                 other_dg_params = (T, r, g_n_vector, g_y)
                 if not baseline_spending:
                     G_0 = ALPHA_G[0] * Y[0]
@@ -886,7 +886,10 @@ def run_TPI(income_tax_params, tpi_params, iterative_params,
     # The re-assignment of G0 & D0 is necessary because Y0 may change
     # in the TPI loop.
     if not budget_balance:
-        D_0 = initial_debt * Y[0]
+        if baseline:
+            D_0 = initial_debt * Y[0]
+        else:
+            D_0 = D0
         other_dg_params = (T, r, g_n_vector, g_y)
         if not baseline_spending:
             G_0 = ALPHA_G[0] * Y[0]
@@ -970,7 +973,10 @@ def run_TPI(income_tax_params, tpi_params, iterative_params,
     C = aggr.get_C(c_path, C_params)
 
     if not budget_balance:
-        D_0 = initial_debt * Y[0]
+        if baseline:
+            D_0 = initial_debt * Y[0]
+        else:
+            D_0 = D0
         other_dg_params = (T, r, g_n_vector, g_y)
         if not baseline_spending:
             G_0 = ALPHA_G[0] * Y[0]

--- a/ogusa/tests/test_TPI.py
+++ b/ogusa/tests/test_TPI.py
@@ -82,9 +82,11 @@ def test_inner_loop():
               'rb') as f:
         input_tuple = pickle.load(f)
     guesses, outer_loop_vars, params = input_tuple
-    income_tax_params, tpi_params, initial_b = params
+    income_tax_params, tpi_params, initial_values, ind = params
+    initial_values = initial_values + (0.0,)
     tpi_params = tpi_params + [True]
-    params = (income_tax_params, tpi_params, initial_b)
+
+    params = (income_tax_params, tpi_params, initial_values, ind)
     test_tuple = TPI.inner_loop(guesses, outer_loop_vars, params)
 
     with open(os.path.join(CUR_PATH,
@@ -113,6 +115,7 @@ def test_run_TPI():
      initial_values, SS_values, fiscal_params, biz_tax_params,
      output_dir, baseline_spending) = input_tuple
     tpi_params = tpi_params + [True]
+    initial_values = initial_values + (0.0,)
     test_dict, not_test_dict = TPI.run_TPI(
         income_tax_params, tpi_params, iterative_params,
         small_open_params, initial_values, SS_values, fiscal_params,

--- a/ogusa/tests/test_TPI.py
+++ b/ogusa/tests/test_TPI.py
@@ -124,20 +124,3 @@ def test_run_TPI():
 
     for k, v in expected_dict.iteritems():
         assert(np.allclose(test_dict[k], v))
-
-
-@pytest.mark.parametrize('input_tuple,expected',
-                         [((1.3, 0.4, 0.0, 0.9, 0.59, 1.9, 3.3),
-                           -0.88988),
-                          ((0.9, 0.2, 1.0, 1.2, 0.7, 2.3, 4.4),
-                           -3.449974203),
-                          ((2.0, 0.8, 0.6, 1.1, 1.22, 5, 6.6),
-                           -2.554169241)],
-                         ids=['epsilon=0', 'epsilon=1', 'epsilon=0.6'])
-def test_initial_GDP_level(input_tuple, expected):
-    # Test TPI.initial_GDP_level.  3 cases: epsilon=1, 0, in (0,1).
-    y_guess, gamma, epsilon, Z, initial_debt, B, L = input_tuple
-    test_error = TPI.initial_GDP_level(y_guess, gamma, epsilon, Z,
-                                       initial_debt, B, L)
-
-    assert(np.allclose(np.array(test_error), np.array(expected)))

--- a/ogusa/tests/test_TPI.py
+++ b/ogusa/tests/test_TPI.py
@@ -39,6 +39,9 @@ def test_firstdoughnutring():
               'rb') as f:
         input_tuple = pickle.load(f)
     guesses, r, w, b, BQ, T_H, j, params = input_tuple
+    income_tax_params, tpi_params, initial_b = params
+    tpi_params = tpi_params + [True]
+    params = (income_tax_params, tpi_params, initial_b)
     test_list = TPI.firstdoughnutring(guesses, r, w, b, BQ, T_H, j, params)
 
     with open(os.path.join(CUR_PATH,
@@ -57,6 +60,9 @@ def test_twist_doughnut():
               'rb') as f:
         input_tuple = pickle.load(f)
     guesses, r, w, BQ, T_H, j, s, t, params = input_tuple
+    income_tax_params, tpi_params, initial_b = params
+    tpi_params = tpi_params + [True]
+    params = (income_tax_params, tpi_params, initial_b)
     test_list = TPI.twist_doughnut(guesses, r, w, BQ, T_H, j, s, t, params)
 
     with open(os.path.join(CUR_PATH,
@@ -76,6 +82,9 @@ def test_inner_loop():
               'rb') as f:
         input_tuple = pickle.load(f)
     guesses, outer_loop_vars, params = input_tuple
+    income_tax_params, tpi_params, initial_b = params
+    tpi_params = tpi_params + [True]
+    params = (income_tax_params, tpi_params, initial_b)
     test_tuple = TPI.inner_loop(guesses, outer_loop_vars, params)
 
     with open(os.path.join(CUR_PATH,
@@ -103,6 +112,7 @@ def test_run_TPI():
     (income_tax_params, tpi_params, iterative_params, small_open_params,
      initial_values, SS_values, fiscal_params, biz_tax_params,
      output_dir, baseline_spending) = input_tuple
+    tpi_params = tpi_params + [True]
     test_dict, not_test_dict = TPI.run_TPI(
         income_tax_params, tpi_params, iterative_params,
         small_open_params, initial_values, SS_values, fiscal_params,

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -994,7 +994,7 @@ def tax_func_loop(t, micro_data, beg_yr, s_min, s_max, age_specific,
     # use weighted avg for MTR labor - abs value because
     # SE income may be negative
     data_orig['MTR labor income'] = \
-        (data_orig['MTR wage'] * (data_orig['Wage income'] /
+        (data_orig['MTR wage income'] * (data_orig['Wage income'] /
                                   (data_orig['Wage income'].abs() +
                                    data_orig['SE income'].abs())) +
          data_orig['MTR SE income'] * (data_orig['SE income'].abs() /


### PR DESCRIPTION
This PR fixed the amount government debt in the initial period to be the same under the baseline and reform policies.  Previously, the debt to GDP ratio was constant across the two sets of policies, but since GDP differed, the amount of debt did as well.  This fixes that issue to keep values determined at the start of time constant across different model runs.