### PR TITLE
Update to using flexible tax functions

### DIFF
--- a/ogusa/parameters.py
+++ b/ogusa/parameters.py
@@ -142,9 +142,9 @@ def get_parameters_from_file():
 def get_parameters(output_base, reform={}, test=False, baseline=False,
                    guid='', user_modifiable=False, metadata=False,
                    run_micro=False, constant_rates=True,
-                   analytical_mtrs=False, age_specific=False,
-                   start_year=DEFAULT_START_YEAR, data=None,
-                   client=None, num_workers=1, **small_open):
+                   analytical_mtrs=False, tax_func_type='DEP',
+                   age_specific=False, start_year=DEFAULT_START_YEAR,
+                   data=None, client=None, num_workers=1, **small_open):
 
     '''
     --------------------------------------------------------------------
@@ -386,6 +386,7 @@ def get_parameters(output_base, reform={}, test=False, baseline=False,
         txfunc.get_tax_func_estimate(BW, S, starting_age, ending_age,
                                      baseline=baseline,
                                      analytical_mtrs=analytical_mtrs,
+                                     tax_func_type=tax_func_type,
                                      age_specific=age_specific,
                                      start_year=start_year,
                                      reform=reform, guid=guid,

--- a/ogusa/scripts/execute.py
+++ b/ogusa/scripts/execute.py
@@ -61,9 +61,9 @@ def runner(output_base, baseline_dir, test=False, time_path=True,
     run_params = ogusa.parameters.get_parameters(
         output_base, reform=reform, test=test, baseline=baseline,
         guid=guid, run_micro=run_micro, constant_rates=constant_rates,
-        analytical_mtrs=analytical_mtrs, age_specific=age_specific,
-        start_year=start_year, data=data, client=client,
-        num_workers=num_workers, **small_open)
+        analytical_mtrs=analytical_mtrs, tax_func_type=tax_func_type,
+        age_specific=age_specific, start_year=start_year, data=data,
+        client=client, num_workers=num_workers, **small_open)
     run_params['analytical_mtrs'] = analytical_mtrs
     run_params['small_open'] = bool(small_open)
     run_params['budget_balance'] = budget_balance

--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -120,6 +120,7 @@ def test_replace_outliers():
     assert np.allclose(act, exp)
 
 
+@pytest.mark.full_run
 def test_txfunc_est():
     # Test txfunc.txfunc_est() function.  The test is that given
     # inputs from previous run, the outputs are unchanged.


### PR DESCRIPTION
This PR fixes an omission in PR #364.  The omission was a missing link to pass the `tax_func_type` from the `execute.runner()` to `parameters.get_parameters()` and then on to the tax function estimation.  As a results, all runs would use the DeBacker, Evans, and Phillips (2018) functions and not the functional form specified by the user.