### PR TITLE
Remove unused Saved_moments directory

### DIFF
--- a/ogusa/SS_graphs.py
+++ b/ogusa/SS_graphs.py
@@ -10,10 +10,6 @@ This py-file calls the following other file(s):
             household.py
             SSinit/ss_init_vars.pkl
             SS/ss_vars.pkl
-            OUTPUT/Saved_moments/params_given.pkl
-            OUTPUT/Saved_moments/params_changed.pkl
-            OUTPUT/Saved_moments/labor_data_moments
-            OUTPUT/Saved_moments/wealth_data_moments.pkl
 ------------------------------------------------------------------------
 '''
 
@@ -106,11 +102,6 @@ ss_init = os.path.join(SS_FIG_DIR, "SSinit/ss_init_vars.pkl")
 variables = pickle.load(open(ss_init, "rb"))
 for key in variables:
     globals()[key] = variables[key]
-# params_given = os.path.join(SS_FIG_DIR, "Saved_moments/params_given.pkl")
-# variables = pickle.load(open(params_given, "rb"))
-# for key in variables:
-#     globals()[key] = variables[key]
-
 
 #globals().update(ogusa.parameters.get_parameters_from_file())
 globals().update(parameters.get_parameters())
@@ -241,11 +232,6 @@ labor_dist = os.path.join(SS_FIG_DIR, "SSinit/labor_dist")
 plt.savefig(labor_dist)
 
 # Plot 2d comparison of labor distribution to data
-# First import the labor data
-labor = os.path.join(COMPARISON_DIR, "Saved_moments/labor_data_moments.pkl")
-variables = pickle.load(open(labor, "rb"))
-for key in variables:
-    globals()[key] = variables[key]
 
 plt.figure()
 plt.plot(np.arange(80) + 20, (nssmat * lambdas).sum(1),
@@ -358,11 +344,6 @@ plt.savefig(euler_errors_laborleisure_SS)
 # '''
 # ssvars = os.path.join(COMPARISON_DIR, "SS/ss_vars.pkl")
 # variables = pickle.load(open(ssvars, "rb"))
-# for key in variables:
-#     globals()[key] = variables[key]
-# params_changed = os.path.join(
-#     COMPARISON_DIR, "Saved_moments/params_changed.pkl")
-# variables = pickle.load(open(params_changed, "rb"))
 # for key in variables:
 #     globals()[key] = variables[key]
 
@@ -622,12 +603,6 @@ plt.savefig(euler_errors_laborleisure_SS)
 ------------------------------------------------------------------------
 '''
 domain = np.linspace(20, 95, 76)
-
-wealth_data_moments = os.path.join(
-    COMPARISON_DIR, "Saved_moments/wealth_data_moments.pkl")
-variables = pickle.load(open(wealth_data_moments, "rb"))
-for key in variables:
-    globals()[key] = variables[key]
 
 wealth_data_tograph = wealth_data_array[2:] / 1000000
 wealth_model_tograph = factor_ss_init * bssmatinit[:76] / 1000000

--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -11,8 +11,6 @@ This py-file calls the following other file(s):
             household.py
             firm.py
             OUTPUT/SS/ss_vars.pkl
-            OUTPUT/Saved_moments/params_given.pkl
-            OUTPUT/Saved_moments/params_changed.pkl
 
 
 This py-file creates the following other file(s):

--- a/ogusa/TPI_graphs.py
+++ b/ogusa/TPI_graphs.py
@@ -11,8 +11,6 @@ This py-file calls the following other file(s):
             TPIinit/TPIinit_vars.pkl
             SS/ss_vars.pkl
             TPI/TPI_vars.pkl
-            OUTPUT/Saved_moments/params_given.pkl
-            OUTPUT/Saved_moments/params_changed.pkl
 ------------------------------------------------------------------------
 '''
 
@@ -44,10 +42,6 @@ for key in variables:
     globals()[key] = variables[key]
 tpi_init = os.path.join(VAR_DIR, "TPIinit/TPIinit_vars.pkl")
 variables = pickle.load(open(tpi_init, "rb"))
-for key in variables:
-    globals()[key] = variables[key]
-params_given = os.path.join(VAR_DIR, "Saved_moments/params_given.pkl")
-variables = pickle.load(open(params_given, "rb"))
 for key in variables:
     globals()[key] = variables[key]
 
@@ -128,10 +122,6 @@ for key in variables:
     globals()[key] = variables[key]
 tpi_vars = os.path.join(VAR_DIR, "TPI/TPI_vars.pkl")
 variables = pickle.load(open(tpi_vars, "rb"))
-for key in variables:
-    globals()[key] = variables[key]
-params_changed = os.path.join(VAR_DIR, "Saved_moments/params_changed.pkl")
-variables = pickle.load(open(params_changed, "rb"))
 for key in variables:
     globals()[key] = variables[key]
 

--- a/ogusa/labor.py
+++ b/ogusa/labor.py
@@ -11,7 +11,6 @@ This py-file creates the following other file(s):
     (make sure that an OUTPUT folder exists)
             OUTPUT/Demographics/labor_dist_data_withfit.png
             OUTPUT/Demographics/data_labor_dist.png
-            OUTPUT/Saved_moments/labor_data_moments.pkl
 ------------------------------------------------------------------------
 '''
 

--- a/ogusa/scripts/execute.py
+++ b/ogusa/scripts/execute.py
@@ -47,10 +47,9 @@ def runner(output_base, baseline_dir, test=False, time_path=True,
         baseline_spending = False
 
     # Create output directory structure
-    saved_moments_dir = os.path.join(output_base, "Saved_moments")
     ss_dir = os.path.join(output_base, "SS")
     tpi_dir = os.path.join(output_base, "TPI")
-    dirs = [saved_moments_dir, ss_dir, tpi_dir]
+    dirs = [ss_dir, tpi_dir]
     for _dir in dirs:
         try:
             print("making dir: ", _dir)

--- a/ogusa/utils.py
+++ b/ogusa/utils.py
@@ -5,9 +5,6 @@ Last updated 4/7/2015
 
 Miscellaneous functions for SS.py and TPI.py.
 
-This python files calls:
-    OUTPUT/Saved_moments/wealth_data_moments.pkl
-
 ------------------------------------------------------------------------
 '''
 

--- a/ogusa/wealth.py
+++ b/ogusa/wealth.py
@@ -12,7 +12,6 @@ This py-file creates the following other file(s):
     (make sure that an OUTPUT folder exists)
             OUTPUT/Demographics/distribution_of_wealth_data.png
             OUTPUT/Demographics/distribution_of_wealth_data_log.png
-            OUTPUT/Saved_moments/wealth_data_moments.pkl
 ------------------------------------------------------------------------
 '''
 


### PR DESCRIPTION
Resolves#370

This PR removes references to the `Saved_moments` directory that was being created but never used.

I'm not sure if there are cases in which this will break the graph scripts – it is reading in data and dumping it into the global namespace and I don't think there is a good way to track down all the side-effects that would have had 🤔 

@jdebacker @rickecon 