### PR TITLE
Set environment python to 3.6 by default

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: ospcdyn
 channels:
 - ospc
 dependencies:
+- python>=3.6
 - setuptools
 - mkl
 - scipy>=0.18.1


### PR DESCRIPTION
Follows on @jdebacker 's PR to make OG-USA compatible with 3.6 in https://github.com/open-source-economics/OG-USA/pull/367 .

This PR makes python 3.6 the default for `ospcdyn`. It also resolves warnings thrown by TaxCalculator when running the model.

Note: I had to run `conda env update --prune` to get around some version conflicts from packages built for 2.7.

cc: @rickecon 