### PR TITLE
Fix example script error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to release. Stay tuned for an upcoming release!
 * Install the [Anaconda distribution](https://www.anaconda.com/distribution/) of Python
 * Clone this repository to a directory on your computer
 * From the terminal (or Conda command prompt), navigate to the directory to which you cloned this repository and run `conda env create -f environment.yml`
-* Then, `source activate ospcdyn`
+* Then, `source activate ospcdyn` (on Mac/Linux) or `conda activate ospcdyn` on Windows.
 * Then install by `python setup.py install` (use `python setup.py develop` if you would like to modifty the code base and run the updated model)
 * Navigate to `./run_examples`
 * Run the model with an example reform from terminal/command prompt by typing `python run_ogusa_example.py`

--- a/run_examples/run_ogusa_example.py
+++ b/run_examples/run_ogusa_example.py
@@ -89,6 +89,10 @@ def run_micro_macro(user_params):
               'baseline_spending': False, 'data': 'cps',
               'client': client, 'num_workers': num_workers}
 
+    start_time = time.time()
+    runner(**kwargs)
+    print('run time = ', time.time()-start_time)
+
     # return ans - the percentage changes in macro aggregates and prices
     # due to policy changes from the baseline to the reform
     ans = postprocess.create_diff(baseline_dir=BASELINE_DIR,


### PR DESCRIPTION
The `run_ogusa_example.py` script was missing a call to `runner()` to run the reform policy.  This PR fixes that omission.